### PR TITLE
Bump minimist and @homebridge/dbus-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,16 +94,16 @@
       }
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.4.1.tgz",
-      "integrity": "sha512-8h6MkoJykY37THOyRXWCIKpzbhIn4WWKZBunlXTH75Cb6vBcmhyIhZ3SvzqJAjJCEdhLg7wawfn7/Mpko7eREQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.4.2.tgz",
+      "integrity": "sha512-rg6DUg6xOttzn73HA1+3G2o1ezRj0+DzPMEJqasrpq7FcAxMcTyOZ96GfcDN4pLUz62hMuywIeVZ4F6cc/g6Ig==",
       "dev": true,
       "dependencies": {
         "@homebridge/long": "^5.2.1",
+        "@homebridge/put": "~0.0.8",
         "event-stream": "^4.0.0",
         "hexy": "^0.2.10",
-        "optimist": "^0.6.1",
-        "put": "0.0.6",
+        "minimist": "^1.2.6",
         "safe-buffer": "^5.1.1",
         "xml2js": "^0.4.17"
       },
@@ -116,6 +116,15 @@
       "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
       "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
       "dev": true
+    },
+    "node_modules/@homebridge/put": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
+      "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.2",
@@ -2456,10 +2465,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -2676,22 +2688,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-      "dev": true
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -2855,15 +2851,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/put": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/put/-/put-0.0.6.tgz",
-      "integrity": "sha1-MPX2C9bkOJvTKeFqJThsuy5KAKM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.0"
       }
     },
     "node_modules/q": {
@@ -3649,15 +3636,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -3814,16 +3792,16 @@
       }
     },
     "@homebridge/dbus-native": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.4.1.tgz",
-      "integrity": "sha512-8h6MkoJykY37THOyRXWCIKpzbhIn4WWKZBunlXTH75Cb6vBcmhyIhZ3SvzqJAjJCEdhLg7wawfn7/Mpko7eREQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.4.2.tgz",
+      "integrity": "sha512-rg6DUg6xOttzn73HA1+3G2o1ezRj0+DzPMEJqasrpq7FcAxMcTyOZ96GfcDN4pLUz62hMuywIeVZ4F6cc/g6Ig==",
       "dev": true,
       "requires": {
         "@homebridge/long": "^5.2.1",
+        "@homebridge/put": "~0.0.8",
         "event-stream": "^4.0.0",
         "hexy": "^0.2.10",
-        "optimist": "^0.6.1",
-        "put": "0.0.6",
+        "minimist": "^1.2.6",
         "safe-buffer": "^5.1.1",
         "xml2js": "^0.4.17"
       }
@@ -3832,6 +3810,12 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
       "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
+      "dev": true
+    },
+    "@homebridge/put": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
+      "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -5557,9 +5541,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {
@@ -5723,24 +5707,6 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5865,12 +5831,6 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
-    },
-    "put": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/put/-/put-0.0.6.tgz",
-      "integrity": "sha1-MPX2C9bkOJvTKeFqJThsuy5KAKM=",
-      "dev": true
     },
     "q": {
       "version": "1.1.2",
@@ -6425,12 +6385,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {


### PR DESCRIPTION
Bumps [minimist](https://github.com/minimistjs/minimist) and [@homebridge/dbus-native](https://github.com/homebridge/dbus-native). These dependencies needed to be updated together.

Updates `minimist` from 1.2.5 to 1.2.8
- [Release notes](https://github.com/minimistjs/minimist/releases)
- [Changelog](https://github.com/minimistjs/minimist/blob/main/CHANGELOG.md)
- [Commits](https://github.com/minimistjs/minimist/compare/v1.2.5...v1.2.8)

Updates `@homebridge/dbus-native` from 0.4.1 to 0.4.2
- [Release notes](https://github.com/homebridge/dbus-native/releases)
- [Commits](https://github.com/homebridge/dbus-native/compare/v0.4.1...v0.4.2)

---
updated-dependencies:
- dependency-name: minimist dependency-type: indirect
- dependency-name: "@homebridge/dbus-native" dependency-type: indirect ...